### PR TITLE
Remove mention of __proto__ being a safe key

### DIFF
--- a/closure/goog/structs/map.js
+++ b/closure/goog/structs/map.js
@@ -20,8 +20,8 @@
  * This file contains an implementation of a Map structure. It implements a lot
  * of the methods used in goog.structs so those functions work on hashes. This
  * is best suited for complex key types. For simple keys such as numbers and
- * strings, and where special names like __proto__ are not a concern, consider
- * using the lighter-weight utilities in goog.object.
+ * strings, and where special names are not a concern, consider using the
+ * lighter-weight utilities in goog.object.
  */
 
 


### PR DESCRIPTION
Fixes https://github.com/google/closure-library/issues/345
