### PR TITLE
Workaround for Compiler error

### DIFF
--- a/closure/goog/test_module.js
+++ b/closure/goog/test_module.js
@@ -22,7 +22,7 @@ goog.module.declareLegacyNamespace();
 
 
 /** @suppress {extraRequire} */
-var dep = goog.require('goog.test_module_dep');
+var _ = goog.require('goog.test_module_dep');
 
 
 


### PR DESCRIPTION
~3 days ago, compiling closure library began throwing this error with the external head compiler: ./closure/goog/test_module.js:25: ERROR - required "goog.test_module_dep" namespace never provided
goog.require('goog.test_module_dep');
